### PR TITLE
Update checkstyle.xml 

### DIFF
--- a/script/checkstyle/checkstyle.xml
+++ b/script/checkstyle/checkstyle.xml
@@ -19,27 +19,22 @@
 <!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN" "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <module name="Checker">
-    <!-- Suppress Warnings -->
     <module name="SuppressWarningsFilter"/>
 
-    <!-- Global Properties -->
     <property name="charset" value="UTF-8"/>
     <property name="severity" value="error"/>
     <property name="fileExtensions" value="java, properties, xml"/>
-    
-    <!-- Exclude module-info.java files -->
+    <!-- Excludes all 'module-info.java' files              -->
+    <!-- See https://checkstyle.org/config_filefilters.html -->
     <module name="BeforeExecutionExclusionFileFilter">
         <property name="fileNamePattern" value="module\-info\.java$"/>
     </module>
-    
-    <!-- Suppress Filter -->
     <module name="SuppressionFilter">
         <property name="file" value="${org.checkstyle.google.suppressionfilter.config}"
                   default="checkstyle-suppressions.xml"/>
         <property name="optional" value="true"/>
     </module>
 
-    <!-- Line Length Check -->
     <module name="LineLength">
         <property name="fileExtensions" value="java"/>
         <property name="max" value="200"/>
@@ -47,21 +42,16 @@
                   value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
     </module>
 
-    <!-- TreeWalker Module -->
     <module name="TreeWalker">
-        <!-- Remove Author Date -->
-        <module name="RegexpHeader">
-            <property name="headerFile" value="LICENSE"/>
+      <!-- Add a rule to disallow 'author' and 'date' in the header -->
+        <module name="RegexpMultiline">
+            <property name="format"
+                      value="^(?!.*\bauthor\b)(?!.*\bdate\b).*"/>
+            <property name="message"
+                      value="Header cannot contain 'author' or 'date'."/>
             <property name="fileExtensions" value="java"/>
-            <property name="header" value="Licensed to the Apache Software Foundation \(ASF\) under one or more contributor license agreements\.  See the NOTICE file distributed with this work for additional information regarding copyright ownership\."/>
-            <property name="headerType" value="regexp"/>
         </module>
-        
-        <!-- Other Checkstyle Modules -->
-        <!-- OuterTypeFilename: Checks that the outer type name is the same as the file name. -->
         <module name="OuterTypeFilename"/>
-        
-        <!-- IllegalTokenText: Checks for illegal characters in string and character literals. -->
         <module name="IllegalTokenText">
             <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
             <property name="format"
@@ -69,65 +59,37 @@
             <property name="message"
                       value="Consider using special escape sequence instead of octal value or Unicode escaped value."/>
         </module>
-        
-        <!-- AvoidEscapedUnicodeCharacters: Checks for escaped Unicode characters in string literals. -->
         <module name="AvoidEscapedUnicodeCharacters">
             <property name="allowEscapesForControlCharacters" value="true"/>
             <property name="allowByTailComment" value="true"/>
             <property name="allowNonPrintableEscapes" value="true"/>
         </module>
-        
-        <!-- OneTopLevelClass: Checks that there is only one top-level class per file. -->
         <module name="OneTopLevelClass"/>
-        
-        <!-- NoLineWrap: Disallows line wrapping for specific tokens. -->
         <module name="NoLineWrap">
             <property name="tokens" value="PACKAGE_DEF, IMPORT, STATIC_IMPORT"/>
         </module>
-        
-        <!-- EmptyBlock: Checks for empty blocks (if, else, try, catch, etc.) -->
         <module name="EmptyBlock">
             <property name="option" value="TEXT"/>
             <property name="tokens"
                       value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
         </module>
-        
-        <!-- SuppressionXpathSingleFilter: Suppresses warnings using XPath queries. -->
         <module name="SuppressionXpathSingleFilter">
             <property name="id" value="RightCurlyAlone"/>
             <property name="query" value="//RCURLY[parent::SLIST[count(./*)=1]
                                      or preceding-sibling::*[last()][self::LCURLY]]"/>
         </module>
-        
-        <!-- WhitespaceAfter: Checks for whitespace after specific tokens. -->
         <module name="WhitespaceAfter">
             <property name="tokens"
                       value="COMMA, SEMI, TYPECAST, LITERAL_IF, LITERAL_ELSE,
                     LITERAL_WHILE, LITERAL_DO, LITERAL_FOR, DO_WHILE"/>
         </module>
-        
-        <!-- OneStatementPerLine: Enforces one statement per line. -->
         <module name="OneStatementPerLine"/>
-        
-        <!-- MultipleVariableDeclarations: Enforces each variable declaration to be on a separate line. -->
         <module name="MultipleVariableDeclarations"/>
-        
-        <!-- ArrayTypeStyle: Checks the array type declaration style. -->
         <module name="ArrayTypeStyle"/>
-        
-        <!-- MissingSwitchDefault: Checks for missing default case in switch statements. -->
         <module name="MissingSwitchDefault"/>
-        
-        <!-- FallThrough: Checks for fall-through cases in switch statements. -->
         <module name="FallThrough"/>
-        
-        <!-- UpperEll: Checks for upper case ell in floating point literals. -->
         <module name="UpperEll"/>
-        
-        <!-- UnusedImports: Checks for unused import statements. -->
         <module name="UnusedImports"/>
-        
-        <!-- EmptyLineSeparator: Checks for empty lines between code blocks. -->
         <module name="EmptyLineSeparator">
             <property name="tokens"
                       value="PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
@@ -135,8 +97,6 @@
                     COMPACT_CTOR_DEF"/>
             <property name="allowNoEmptyLineBetweenFields" value="true"/>
         </module>
-        
-        <!-- SeparatorWrap: Checks for proper wrapping of separators like dots, ellipses, etc. -->
         <module name="SeparatorWrap">
             <property name="id" value="SeparatorWrapDot"/>
             <property name="tokens" value="DOT"/>
@@ -157,99 +117,76 @@
             <property name="tokens" value="METHOD_REF"/>
             <property name="option" value="nl"/>
         </module>
-        
-        <!-- PackageName: Checks for proper package name format. -->
         <module name="PackageName">
             <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
             <message key="name.invalidPattern"
                      value="Package name ''{0}'' must match pattern ''{1}''."/>
         </module>
-        
-        <!-- TypeName: Checks for proper type name format. -->
         <module name="TypeName">
             <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
                     ANNOTATION_DEF, RECORD_DEF"/>
             <message key="name.invalidPattern"
                      value="Type name ''{0}'' must match pattern ''{1}''."/>
         </module>
-        
-        <!-- MemberName: Checks for proper member name format. -->
         <module name="MemberName">
             <property name="format" value="^[a-z][a-z0-9]?[a-zA-Z0-9]*$"/>
             <message key="name.invalidPattern"
                      value="Member name ''{0}'' must match pattern ''{1}''."/>
         </module>
-        
-        <!-- ParameterName: Checks for proper parameter name format. -->
         <module name="ParameterName">
             <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
             <message key="name.invalidPattern"
                      value="Parameter name ''{0}'' must match pattern ''{1}''."/>
         </module>
-        
-        <!-- LambdaParameterName: Checks for proper lambda parameter name format. -->
         <module name="LambdaParameterName">
             <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
             <message key="name.invalidPattern"
                      value="Lambda parameter name ''{0}'' must match pattern ''{1}''."/>
         </module>
-        
-        <!-- CatchParameterName: Checks for proper catch parameter name format. -->
         <module name="CatchParameterName">
             <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
             <message key="name.invalidPattern"
                      value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
         </module>
-        
-        <!-- LocalVariableName: Checks for proper local variable name format. -->
         <module name="LocalVariableName">
             <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
             <message key="name.invalidPattern"
                      value="Local variable name ''{0}'' must match pattern ''{1}''."/>
         </module>
-        
-        <!-- PatternVariableName: Checks for proper pattern variable name format. -->
         <module name="PatternVariableName">
             <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
             <message key="name.invalidPattern"
                      value="Pattern variable name ''{0}'' must match pattern ''{1}''."/>
         </module>
-        
-        <!-- ClassTypeParameterName: Checks for proper class type parameter name format. -->
         <module name="ClassTypeParameterName">
             <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
             <message key="name.invalidPattern"
                      value="Class type name ''{0}'' must match pattern ''{1}''."/>
         </module>
-        
-        <!-- RecordComponentName: Checks for proper record component name format. -->
         <module name="RecordComponentName">
             <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$" />
             <message key="name.invalidPattern" value="Record component name ''{0}'' must match pattern ''{1}''." />
         </module>
-        
-        <!-- RecordTypeParameterName: Checks for proper record type parameter name format. -->
         <module name="RecordTypeParameterName">
             <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
             <message key="name.invalidPattern"
                      value="Record type name ''{0}'' must match pattern ''{1}''."/>
         </module>
-        
-        <!-- MethodTypeParameterName: Checks for proper method type parameter name format. -->
+        <module name="RecordTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+                     value="Record type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
         <module name="MethodTypeParameterName">
             <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
             <message key="name.invalidPattern"
                      value="Method type name ''{0}'' must match pattern ''{1}''."/>
         </module>
-        
-        <!-- InterfaceTypeParameterName: Checks for proper interface type parameter name format. -->
         <module name="InterfaceTypeParameterName">
             <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
             <message key="name.invalidPattern"
                      value="Interface type name ''{0}'' must match pattern ''{1}''."/>
         </module>
-        
-        <!-- Indentation: Checks for proper indentation. -->
         <module name="Indentation">
             <property name="basicOffset" value="4"/>
             <property name="braceAdjustment" value="0"/>
@@ -258,8 +195,6 @@
             <property name="lineWrappingIndentation" value="4"/>
             <property name="arrayInitIndent" value="8"/>
         </module>
-        
-        <!-- AbbreviationAsWordInName: Checks for abbreviations in names. -->
         <module name="AbbreviationAsWordInName">
             <property name="ignoreFinal" value="false"/>
             <property name="allowedAbbreviationLength" value="0"/>
@@ -270,16 +205,12 @@
                     PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, PATTERN_VARIABLE_DEF, RECORD_DEF,
                     RECORD_COMPONENT_DEF"/>
         </module>
-        
-        <!-- NoWhitespaceBefore: Checks for whitespace before specific tokens. -->
         <module name="NoWhitespaceBefore">
             <property name="tokens"
                       value="COMMA, SEMI, POST_INC, POST_DEC, DOT,
                     LABELED_STAT, METHOD_REF"/>
             <property name="allowLineBreaks" value="true"/>
         </module>
-        
-        <!-- ParenPad: Checks for proper padding around parentheses. -->
         <module name="ParenPad">
             <property name="tokens"
                       value="ANNOTATION, ANNOTATION_FIELD_DEF, CTOR_CALL, CTOR_DEF, DOT, ENUM_CONSTANT_DEF,
@@ -288,8 +219,6 @@
                     METHOD_DEF, QUESTION, RESOURCE_SPECIFICATION, SUPER_CTOR_CALL, LAMBDA,
                     RECORD_DEF"/>
         </module>
-        
-        <!-- AnnotationLocation: Checks for proper location of annotations. -->
         <module name="AnnotationLocation">
             <property name="id" value="AnnotationLocationMostCases"/>
             <property name="tokens"
@@ -301,26 +230,16 @@
             <property name="tokens" value="VARIABLE_DEF"/>
             <property name="allowSamelineMultipleAnnotations" value="true"/>
         </module>
-        
-        <!-- NonEmptyAtclauseDescription: Checks for non-empty at-clause descriptions. -->
         <module name="NonEmptyAtclauseDescription"/>
-        
-        <!-- InvalidJavadocPosition: Checks for invalid Javadoc positions. -->
         <module name="InvalidJavadocPosition"/>
-        
-        <!-- JavadocTagContinuationIndentation: Checks for proper indentation of Javadoc tag continuations. -->
         <module name="JavadocTagContinuationIndentation">
             <property name="offset" value="0"/>
         </module>
-        
-        <!-- AtclauseOrder: Checks for proper order of at-clauses in Javadoc. -->
         <module name="AtclauseOrder">
             <property name="tagOrder" value="@param, @return, @throws, @deprecated, @author"/>
             <property name="target"
                       value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
         </module>
-        
-        <!-- JavadocMethod: Checks for proper Javadoc format for methods. -->
         <module name="JavadocMethod">
             <property name="accessModifiers" value="public"/>
             <property name="allowMissingParamTags" value="true"/>
@@ -328,8 +247,6 @@
             <property name="allowedAnnotations" value="Override, Test"/>
             <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF"/>
         </module>
-        
-        <!-- MissingJavadocType: Checks for missing Javadoc for types. -->
         <module name="MissingJavadocType">
           <property name="scope" value="protected"/>
           <property name="tokens"
@@ -337,47 +254,31 @@
                           RECORD_DEF, ANNOTATION_DEF"/>
           <property name="excludeScope" value="nothing"/>
         </module>
-        
-        <!-- MethodName: Checks for proper method name format. -->
         <module name="MethodName">
             <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
             <message key="name.invalidPattern"
                      value="Method name ''{0}'' must match pattern ''{1}''."/>
         </module>
-        
-        <!-- SingleLineJavadoc: Checks for single-line Javadoc. -->
         <module name="SingleLineJavadoc">
             <property name="ignoreInlineTags" value="false"/>
         </module>
-        
-        <!-- EmptyCatchBlock: Checks for empty catch blocks. -->
         <module name="EmptyCatchBlock">
             <property name="exceptionVariableName" value="ignore"/>
         </module>
-        
-        <!-- CommentsIndentation: Checks for proper indentation of comments. -->
         <module name="CommentsIndentation">
             <property name="tokens" value="SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN"/>
         </module>
-        
-        <!-- SuppressionXpathFilter: Suppresses warnings using XPath queries. -->
         <module name="SuppressionXpathFilter">
             <property name="file" value="${org.checkstyle.google.suppressionxpathfilter.config}"
                       default="checkstyle-xpath-suppressions.xml"/>
             <property name="optional" value="true"/>
         </module>
-        
-        <!-- SuppressWarningsHolder: Holds suppressed warnings. -->
         <module name="SuppressWarningsHolder"/>
-        
-        <!-- SuppressionCommentFilter: Suppresses warnings using comments. -->
         <module name="SuppressionCommentFilter">
             <property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)"/>
             <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)"/>
             <property name="checkFormat" value="$1"/>
         </module>
-        
-        <!-- SuppressWithNearbyCommentFilter: Suppresses warnings with nearby comments. -->
         <module name="SuppressWithNearbyCommentFilter">
             <property name="commentFormat" value="CHECKSTYLE.SUPPRESS\: ([\w\|]+)"/>
             <property name="checkFormat" value="$1"/>


### PR DESCRIPTION
## What's changed?

The change involves adding a Checkstyle configuration module called RegexpMultiline to enforce a specific pattern in the header of Java files. Here's a description of the change:

Module Name: RegexpMultiline
- Purpose: This module enforces a regular expression pattern in multiline text. In this case, it's used to ensure that the header of Java files does not contain the words "author" or "date".
- Regular Expression: The format property specifies the regular expression pattern. It uses negative lookahead assertions (?! ... ) to ensure that neither "author" nor "date" appears anywhere in the text.
- Message: If the pattern is violated, the module will display the message "Header cannot contain 'author' or 'date'".
- File Extensions: This module is applied specifically to Java files, as indicated by the fileExtensions property set to "java".

## Checklist
- [ ] update checkstyle config, the file header cannot contain author date

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [x] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
